### PR TITLE
feat: 实现多模型配置和选择功能

### DIFF
--- a/backend/ai_service.py
+++ b/backend/ai_service.py
@@ -46,11 +46,11 @@ class DocumentIssues(BaseModel):
 class AIService:
     """AI服务封装 - 使用LangChain和OpenAI兼容API"""
     
-    def __init__(self, db_session: Optional[Session] = None):
+    def __init__(self, db_session: Optional[Session] = None, model_index: Optional[int] = None):
         """初始化AI服务"""
         self.db = db_session
         # 使用配置加载器获取配置
-        self.config = get_ai_service_config()
+        self.config = get_ai_service_config(model_index)
         
         # 从配置中提取参数
         self.provider = self.config['provider']

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,47 +1,132 @@
+# 服务器配置
+server:
+  host: "0.0.0.0"  # 监听地址
+  port: 8124  # 监听端口
+  debug: false  # 调试模式
+  reload: false  # 自动重载
+  workers: 1  # 工作进程数
+
 # 数据库
 database: ./data/app.db
 
-# AI服务配置
-ai_service:
-  # 模型提供商：openai, anthropic, azure, custom
-  provider: "openai"
+# AI模型配置 - 支持多模型
+ai_models:
+  # 默认使用的模型索引（从0开始）
+  default_index: 0
   
-  # OpenAI配置
-  openai:
-    api_key: "${OPENAI_API_KEY}"  # 从环境变量获取，或直接填写
-    base_url: "https://api.openai.com/v1"  # API端点，可自定义
-    model: "gpt-4o-mini"  # 使用的模型
-    temperature: 0.3  # 温度参数，控制创造性
-    max_tokens: 4096  # 最大token数
-    timeout: 30  # 请求超时时间（秒）
-    max_retries: 3  # 最大重试次数
-    
-  # Anthropic配置（备选）
-  anthropic:
-    api_key: "${ANTHROPIC_API_KEY}"  # 从环境变量获取
-    base_url: "${ANTHROPIC_BASE_URL}"  # 自定义端点
-    model: "claude-3-haiku-20240307"  # 使用的模型
-    temperature: 0.3
-    max_tokens: 4096
-    timeout: 30
-    max_retries: 3
-    
-  # 通用配置
-  default:
-    temperature: 0.3
-    max_tokens: 4096
-    timeout: 30
-    max_retries: 3
-    
-  # 降级策略
-  fallback:
-    enabled: true  # 是否启用降级
-    provider: "anthropic"  # 降级到的提供商
-    
-# 文件设置  
-max_file_size: 10485760  # 10MB
-chunk_size: 8000
+  # 模型列表
+  models:
+    - label: "GPT-4o Mini (快速)"  # 前端显示名称
+      provider: "openai"
+      config:
+        api_key: "${OPENAI_API_KEY}"  # 从环境变量获取
+        base_url: "https://api.openai.com/v1"
+        model: "gpt-4o-mini"
+        temperature: 0.3
+        max_tokens: 4096
+        timeout: 30
+        max_retries: 3
+      description: "适合快速处理，成本较低"
+      
+    - label: "GPT-4 Turbo (精准)"  # 前端显示名称
+      provider: "openai"
+      config:
+        api_key: "${OPENAI_API_KEY}"
+        base_url: "https://api.openai.com/v1"
+        model: "gpt-4-turbo-preview"
+        temperature: 0.2
+        max_tokens: 8192
+        timeout: 60
+        max_retries: 3
+      description: "更高精度，适合复杂文档"
+      
+    - label: "Claude 3 Haiku (高效)"  # 前端显示名称
+      provider: "anthropic"
+      config:
+        api_key: "${ANTHROPIC_API_KEY}"
+        base_url: "${ANTHROPIC_BASE_URL}"
+        model: "claude-3-haiku-20240307"
+        temperature: 0.3
+        max_tokens: 4096
+        timeout: 30
+        max_retries: 3
+      description: "平衡速度和质量"
+      
+    - label: "Claude 3 Sonnet (专业)"  # 前端显示名称
+      provider: "anthropic"
+      config:
+        api_key: "${ANTHROPIC_API_KEY}"
+        base_url: "${ANTHROPIC_BASE_URL}"
+        model: "claude-3-sonnet-20240229"
+        temperature: 0.2
+        max_tokens: 8192
+        timeout: 60
+        max_retries: 3
+      description: "专业级分析，适合技术文档"
+      
+    - label: "本地模型 (私有部署)"  # 前端显示名称
+      provider: "custom"
+      config:
+        api_key: "not-needed"
+        base_url: "http://localhost:11434/v1"  # 例如 Ollama API
+        model: "llama2"
+        temperature: 0.3
+        max_tokens: 4096
+        timeout: 120
+        max_retries: 2
+      description: "数据不出境，适合敏感文档"
 
-# 目录
-upload_dir: ./data/uploads
-report_dir: ./data/reports
+# 降级策略
+fallback:
+  enabled: true  # 是否启用降级
+  strategy: "next"  # 降级策略: next(下一个模型), specific(指定模型)
+  specific_index: 2  # 当strategy为specific时，降级到的模型索引
+
+# 文件设置  
+file_settings:
+  max_file_size: 10485760  # 10MB
+  chunk_size: 8000  # 文本分块大小
+  allowed_extensions:
+    - pdf
+    - docx
+    - md
+    - txt
+
+# 目录配置
+directories:
+  upload_dir: ./data/uploads
+  report_dir: ./data/reports
+  log_dir: ./data/logs
+  temp_dir: ./data/temp
+
+# 日志配置
+logging:
+  level: "INFO"  # DEBUG, INFO, WARNING, ERROR
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  file: "./data/logs/app.log"
+  max_size: 10485760  # 10MB
+  backup_count: 5
+
+# 任务处理配置
+task_processing:
+  max_concurrent_tasks: 3  # 最大并发任务数
+  task_timeout: 3600  # 任务超时时间（秒）
+  retry_failed_tasks: true  # 是否重试失败的任务
+  
+# CORS配置
+cors:
+  enabled: true
+  origins:
+    - "http://localhost:3000"
+    - "http://localhost:3001"
+    - "http://localhost:3002"
+    - "http://localhost:3003"
+  allow_credentials: true
+  allow_methods: ["*"]
+  allow_headers: ["*"]
+
+# 环境变量映射（可选）
+env_mapping:
+  OPENAI_API_KEY: "OPENAI_API_KEY"
+  ANTHROPIC_API_KEY: "ANTHROPIC_AUTH_TOKEN"
+  ANTHROPIC_BASE_URL: "ANTHROPIC_BASE_URL"

--- a/backend/config_loader.py
+++ b/backend/config_loader.py
@@ -25,13 +25,59 @@ class ConfigLoader:
         return value
     
     @staticmethod
-    def get_ai_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    def get_ai_config(config: Dict[str, Any], model_index: Optional[int] = None) -> Dict[str, Any]:
         """
         获取AI服务配置
+        
+        Args:
+            config: 主配置字典
+            model_index: 模型索引（用于新的多模型配置）
         
         Returns:
             包含所有必要配置的字典
         """
+        # 检查是否使用新的多模型配置格式
+        if 'ai_models' in config:
+            models_config = config.get('ai_models', {})
+            models = models_config.get('models', [])
+            
+            # 使用指定的模型索引或默认索引
+            if model_index is None:
+                model_index = models_config.get('default_index', 0)
+            
+            # 确保索引有效
+            if 0 <= model_index < len(models):
+                model_config = models[model_index]
+                provider = model_config.get('provider', 'openai')
+                inner_config = model_config.get('config', {})
+                
+                # 解析环境变量
+                resolved_config = {}
+                for key, value in inner_config.items():
+                    resolved_config[key] = ConfigLoader.resolve_env_var(value)
+                
+                result = {
+                    'provider': provider,
+                    'api_key': resolved_config.get('api_key', 'dummy-key'),
+                    'base_url': resolved_config.get('base_url', 'https://api.openai.com/v1'),
+                    'model': resolved_config.get('model', 'gpt-4o-mini'),
+                    'temperature': float(resolved_config.get('temperature', 0.3)),
+                    'max_tokens': int(resolved_config.get('max_tokens', 4096)),
+                    'timeout': int(resolved_config.get('timeout', 30)),
+                    'max_retries': int(resolved_config.get('max_retries', 3)),
+                    'model_label': model_config.get('label', f'Model {model_index}'),
+                    'model_index': model_index
+                }
+                
+                # 添加降级策略配置
+                fallback_config = config.get('fallback', {})
+                result['fallback_enabled'] = fallback_config.get('enabled', False)
+                result['fallback_strategy'] = fallback_config.get('strategy', 'next')
+                result['fallback_specific_index'] = fallback_config.get('specific_index', 0)
+                
+                return result
+        
+        # 兼容旧的配置格式
         ai_config = config.get('ai_service', {})
         provider = ai_config.get('provider', 'openai')
         
@@ -72,7 +118,7 @@ def get_config() -> Dict[str, Any]:
     return ConfigLoader.load_config()
 
 
-def get_ai_service_config() -> Dict[str, Any]:
+def get_ai_service_config(model_index: Optional[int] = None) -> Dict[str, Any]:
     """获取AI服务配置"""
     config = get_config()
-    return ConfigLoader.get_ai_config(config)
+    return ConfigLoader.get_ai_config(config, model_index)

--- a/backend/database.py
+++ b/backend/database.py
@@ -26,6 +26,7 @@ class Task(Base):
     file_type = Column(String(20))
     status = Column(String(20), default="pending")  # pending/processing/completed/failed
     progress = Column(Float, default=0)
+    model_index = Column(Integer, default=0)  # 使用的模型索引
     created_at = Column(DateTime, default=datetime.now)
     completed_at = Column(DateTime, nullable=True)
     error_message = Column(Text, nullable=True)

--- a/backend/task_processor.py
+++ b/backend/task_processor.py
@@ -29,14 +29,14 @@ class TaskProcessor:
         # 获取日志管理器
         logger = await TaskLoggerFactory.get_logger(str(task_id), "task_processor")
         
-        # 初始化AI服务，传入数据库会话
-        self.ai_service = AIService(db_session=db)
-        
-        # 获取任务
+        # 获取任务配置的模型索引并初始化AI服务
         task = db.query(Task).filter(Task.id == task_id).first()
         if not task:
             await logger.error(f"任务不存在: {task_id}")
             return
+        
+        # 初始化AI服务，传入数据库会话和模型索引
+        self.ai_service = AIService(db_session=db, model_index=task.model_index)
         
         # 更新状态为处理中
         task.status = 'processing'
@@ -103,7 +103,12 @@ class TaskProcessor:
                     description=issue_data.get('description', ''),
                     location=issue_data.get('location', ''),
                     severity=issue_data.get('severity', '中'),
-                    suggestion=issue_data.get('suggestion', '')
+                    suggestion=issue_data.get('suggestion', ''),
+                    # 新增字段
+                    original_text=issue_data.get('original_text', ''),
+                    user_impact=issue_data.get('user_impact', ''),
+                    reasoning=issue_data.get('reasoning', ''),
+                    context=issue_data.get('context', '')
                 )
                 db.add(issue)
             

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,11 +13,14 @@ const api = axios.create({
 
 export const taskAPI = {
   // 创建任务
-  createTask: async (file: File, title?: string) => {
+  createTask: async (file: File, title?: string, modelIndex?: number) => {
     const formData = new FormData();
     formData.append('file', file);
     if (title) {
       formData.append('title', title);
+    }
+    if (modelIndex !== undefined) {
+      formData.append('model_index', modelIndex.toString());
     }
     
     const response = await api.post<Task>('/tasks', formData, {


### PR DESCRIPTION
主要功能：
1. 支持多个AI模型配置，每个模型可设置label参数用于前端显示
2. 通过命令行参数(--config)加载不同配置文件
3. 服务器启动参数（host、port等）可在配置文件中设置
4. 前端任务创建时支持选择不同模型进行分析

技术改进：
- 重构config.yaml支持多模型列表配置
- 更新config_loader支持model_index参数
- main.py新增/api/models端点返回可用模型列表
- 数据库Task表新增model_index字段
- 前端TaskCreate组件添加模型选择下拉框
- AI服务根据任务的model_index使用对应模型配置

配置示例：
- 默认配置包含5个预设模型（GPT-4、Claude等）
- 支持环境变量替换（${OPENAI_API_KEY}等）
- 支持降级策略和容错处理

🤖 Generated with [Claude Code](https://claude.ai/code)